### PR TITLE
Added support for storage flags in Codec

### DIFF
--- a/src/main/scala/shade/memcached/Memcached.scala
+++ b/src/main/scala/shade/memcached/Memcached.scala
@@ -28,20 +28,20 @@ trait Memcached extends java.io.Closeable {
    *
    * @return either true, in case the value was set, or false otherwise
    */
-  def add[T](key: String, value: T, exp: Duration)(implicit codec: Codec[T]): CancelableFuture[Boolean]
+  def add[T](key: String, value: T, flags: Int, exp: Duration)(implicit codec: Codec[T]): CancelableFuture[Boolean]
 
-  def awaitAdd[T](key: String, value: T, exp: Duration)(implicit codec: Codec[T]): Boolean =
-    Await.result(add(key, value, exp), Duration.Inf)
+  def awaitAdd[T](key: String, value: T, flags: Int, exp: Duration)(implicit codec: Codec[T]): Boolean =
+    Await.result(add(key, value, flags, exp), Duration.Inf)
 
   /**
    * Sets a (key, value) in the cache store.
    *
    * The expiry time can be Duration.Inf (infinite duration).
    */
-  def set[T](key: String, value: T, exp: Duration)(implicit codec: Codec[T]): CancelableFuture[Unit]
+  def set[T](key: String, value: T, flags: Int, exp: Duration)(implicit codec: Codec[T]): CancelableFuture[Unit]
 
-  def awaitSet[T](key: String, value: T, exp: Duration)(implicit codec: Codec[T]) {
-    Await.result(set(key, value, exp), Duration.Inf)
+  def awaitSet[T](key: String, value: T, flags: Int, exp: Duration)(implicit codec: Codec[T]) {
+    Await.result(set(key, value, flags, exp), Duration.Inf)
   }
 
   /**
@@ -71,7 +71,7 @@ trait Memcached extends java.io.Closeable {
    * @param exp can be Duration.Inf (infinite) for not setting an expiration
    * @return either true (in case the compare-and-set succeeded) or false otherwise
    */
-  def compareAndSet[T](key: String, expecting: Option[T], newValue: T, exp: Duration)(implicit codec: Codec[T]): Future[Boolean]
+  def compareAndSet[T](key: String, expecting: Option[T], newValue: T, flags: Int, exp: Duration)(implicit codec: Codec[T]): Future[Boolean]
 
   /**
    * Transforms the given key and returns the new value.

--- a/src/main/scala/shade/memcached/internals/Result.scala
+++ b/src/main/scala/shade/memcached/internals/Result.scala
@@ -12,5 +12,5 @@
 package shade.memcached.internals
 
 sealed trait Result[+T]
-case class SuccessfulResult[+T](key: String, result: T) extends Result[T]
+case class SuccessfulResult[+T](key: String, result: T, flags: Int) extends Result[T]
 case class FailedResult(key: String, state: Status) extends Result[Nothing]

--- a/src/main/scala/shade/memcached/internals/SpyMemcachedIntegration.scala
+++ b/src/main/scala/shade/memcached/internals/SpyMemcachedIntegration.scala
@@ -186,14 +186,14 @@ class SpyMemcachedIntegration(cf: ConnectionFactory, addrs: Seq[InetSocketAddres
       def receivedStatus(opStatus: OperationStatus) {
         handleStatus(opStatus, key, result) {
           case CASNotFoundStatus =>
-            result.tryComplete(Success(SuccessfulResult(key, None)))
+            result.tryComplete(Success(SuccessfulResult(key, None, 0)))
           case CASSuccessStatus =>
         }
       }
 
       def gotData(k: String, flags: Int, data: Array[Byte]) {
         assert(key == k, "Wrong key returned")
-        result.tryComplete(Success(SuccessfulResult(key, Option(data))))
+        result.tryComplete(Success(SuccessfulResult(key, Option(data), flags)))
       }
 
       def complete() {
@@ -217,7 +217,7 @@ class SpyMemcachedIntegration(cf: ConnectionFactory, addrs: Seq[InetSocketAddres
       }
 
       def gotData(key: String, cas: Long) {
-        result.tryComplete(Success(SuccessfulResult(key, cas)))
+        result.tryComplete(Success(SuccessfulResult(key, cas, flags)))
       }
 
       def complete() {
@@ -237,13 +237,13 @@ class SpyMemcachedIntegration(cf: ConnectionFactory, addrs: Seq[InetSocketAddres
       def receivedStatus(opStatus: OperationStatus) {
         handleStatus(opStatus, key, result) {
           case CASExistsStatus =>
-            result.tryComplete(Success(SuccessfulResult(key, None)))
+            result.tryComplete(Success(SuccessfulResult(key, None, flags)))
           case CASSuccessStatus =>
         }
       }
 
       def gotData(key: String, cas: Long) {
-        result.tryComplete(Success(SuccessfulResult(key, Some(cas))))
+        result.tryComplete(Success(SuccessfulResult(key, Some(cas), flags)))
       }
 
       def complete() {
@@ -269,9 +269,9 @@ class SpyMemcachedIntegration(cf: ConnectionFactory, addrs: Seq[InetSocketAddres
       def receivedStatus(opStatus: OperationStatus) {
         handleStatus(opStatus, key, result) {
           case CASSuccessStatus =>
-            result.tryComplete(Success(SuccessfulResult(key, true)))
+            result.tryComplete(Success(SuccessfulResult(key, true, 0)))
           case CASNotFoundStatus =>
-            result.tryComplete(Success(SuccessfulResult(key, false)))
+            result.tryComplete(Success(SuccessfulResult(key, false, 0)))
         }
       }
     })
@@ -288,7 +288,7 @@ class SpyMemcachedIntegration(cf: ConnectionFactory, addrs: Seq[InetSocketAddres
       def receivedStatus(opStatus: OperationStatus) {
         handleStatus(opStatus, key, result) {
           case CASNotFoundStatus =>
-            result.tryComplete(Success(SuccessfulResult(key, None)))
+            result.tryComplete(Success(SuccessfulResult(key, None, 0)))
           case CASSuccessStatus =>
         }
       }
@@ -298,7 +298,7 @@ class SpyMemcachedIntegration(cf: ConnectionFactory, addrs: Seq[InetSocketAddres
         assert(cas > 0, s"CAS was less than zero:  $cas")
 
         result.tryComplete(Try {
-          SuccessfulResult(key, Option(data).map(d => (d, cas)))
+          SuccessfulResult(key, Option(data).map(d => (d, cas)), flags)
         })
       }
 
@@ -319,11 +319,11 @@ class SpyMemcachedIntegration(cf: ConnectionFactory, addrs: Seq[InetSocketAddres
       def receivedStatus(opStatus: OperationStatus) {
         handleStatus(opStatus, key, result) {
           case CASSuccessStatus =>
-            result.tryComplete(Success(SuccessfulResult(key, true)))
+            result.tryComplete(Success(SuccessfulResult(key, true, flags)))
           case CASExistsStatus =>
-            result.tryComplete(Success(SuccessfulResult(key, false)))
+            result.tryComplete(Success(SuccessfulResult(key, false, flags)))
           case CASNotFoundStatus =>
-            result.tryComplete(Success(SuccessfulResult(key, false)))
+            result.tryComplete(Success(SuccessfulResult(key, false, flags)))
         }
       }
 
@@ -353,7 +353,7 @@ class SpyMemcachedIntegration(cf: ConnectionFactory, addrs: Seq[InetSocketAddres
       def receivedStatus(opStatus: OperationStatus) {
         handleStatus(opStatus, key, result) {
           case CASSuccessStatus =>
-            result.tryComplete(Success(SuccessfulResult(key, opStatus.getMessage.toLong)))
+            result.tryComplete(Success(SuccessfulResult(key, opStatus.getMessage.toLong, 0)))
         }
       }
 

--- a/src/test/scala/shade/memcached/internals/MutablePartialResultSuite.scala
+++ b/src/test/scala/shade/memcached/internals/MutablePartialResultSuite.scala
@@ -26,7 +26,7 @@ class MutablePartialResultSuite
     val promise = Promise[Result[Boolean]]()
     toCheck.completePromise("key1", promise)
     whenReady(promise.future) {
-      case SuccessfulResult(_, r) => assert(r == expected)
+      case SuccessfulResult(_, r, _) => assert(r == expected)
       case _ => fail("not successful")
     }
   }
@@ -42,27 +42,27 @@ class MutablePartialResultSuite
 
   test("#tryComplete on a fresh MutablePartialResult") {
     val pResult = new MutablePartialResult[Boolean]
-    pResult.tryComplete(Success(SuccessfulResult("key1", false)))
+    pResult.tryComplete(Success(SuccessfulResult("key1", false, 0)))
     assertCompletePromise(toCheck = pResult, expected = false)
   }
 
   test("#tryComplete on a MutablePartialResult that has already been completed") {
     val pResult = new MutablePartialResult[Boolean]
-    assert(pResult.tryComplete(Success(SuccessfulResult("key1", false))))
-    assert(!pResult.tryComplete(Success(SuccessfulResult("key1", true))))
+    assert(pResult.tryComplete(Success(SuccessfulResult("key1", false, 0))))
+    assert(!pResult.tryComplete(Success(SuccessfulResult("key1", true, 0))))
     assertCompletePromise(toCheck = pResult, expected = false)
   }
 
   test("#tryCompleteWith on a fresh MutablePartialResult") {
     val pResult = new MutablePartialResult[Boolean]
-    pResult.tryCompleteWith(Future.successful(SuccessfulResult("key1", false)))
+    pResult.tryCompleteWith(Future.successful(SuccessfulResult("key1", false, 0)))
     assertCompletePromise(toCheck = pResult, expected = false)
   }
 
   test("#tryCompleteWith on a MutablePartialResult that has already been completed") {
     val pResult = new MutablePartialResult[Boolean]
-    assert(pResult.tryCompleteWith(Future.successful(SuccessfulResult("key1", false))))
-    assert(!pResult.tryCompleteWith(Future.successful(SuccessfulResult("key1", true))))
+    assert(pResult.tryCompleteWith(Future.successful(SuccessfulResult("key1", false, 0))))
+    assert(!pResult.tryCompleteWith(Future.successful(SuccessfulResult("key1", true, 0))))
     assertCompletePromise(toCheck = pResult, expected = false)
   }
 

--- a/src/test/scala/shade/tests/CodecsSuite.scala
+++ b/src/test/scala/shade/tests/CodecsSuite.scala
@@ -23,8 +23,8 @@ class CodecsSuite extends FunSuite with MemcachedCodecs with GeneratorDrivenProp
    */
   private def serdesCheck[A: Arbitrary](codec: Codec[A]): Unit = {
     forAll { n: A =>
-      val serialised = codec.serialize(n)
-      val deserialised = codec.deserialize(serialised)
+      val serialised = codec.serialize(n, 0)
+      val deserialised = codec.deserialize(serialised, 0)
       assert(deserialised == n)
     }
   }

--- a/src/test/scala/shade/tests/FakeMemcachedSuite.scala
+++ b/src/test/scala/shade/tests/FakeMemcachedSuite.scala
@@ -25,13 +25,13 @@ class FakeMemcachedSuite extends FunSuite with MemcachedTestHelpers {
 
   test("add") {
     withFakeMemcached { cache =>
-      val op1 = cache.awaitAdd("hello", Value("world"), 5.seconds)
+      val op1 = cache.awaitAdd("hello", Value("world"), 0, 5.seconds)
       assert(op1 === true)
 
       val stored = cache.awaitGet[Value]("hello")
       assert(stored === Some(Value("world")))
 
-      val op2 = cache.awaitAdd("hello", Value("changed"), 5.seconds)
+      val op2 = cache.awaitAdd("hello", Value("changed"), 0, 5.seconds)
       assert(op2 === false)
 
       val changed = cache.awaitGet[Value]("hello")
@@ -41,7 +41,7 @@ class FakeMemcachedSuite extends FunSuite with MemcachedTestHelpers {
 
   test("add-null") {
     withFakeMemcached { cache =>
-      val op1 = cache.awaitAdd("hello", null, 5.seconds)
+      val op1 = cache.awaitAdd("hello", null, 0, 5.seconds)
       assert(op1 === false)
 
       val stored = cache.awaitGet[Value]("hello")
@@ -60,10 +60,10 @@ class FakeMemcachedSuite extends FunSuite with MemcachedTestHelpers {
     withFakeMemcached { cache =>
       assert(cache.awaitGet[Value]("hello") === None)
 
-      cache.awaitSet("hello", Value("world"), 3.seconds)
+      cache.awaitSet("hello", Value("world"), 0, 3.seconds)
       assert(cache.awaitGet[Value]("hello") === Some(Value("world")))
 
-      cache.awaitSet("hello", Value("changed"), 3.seconds)
+      cache.awaitSet("hello", Value("changed"), 0, 3.seconds)
       assert(cache.awaitGet[Value]("hello") === Some(Value("changed")))
 
       Thread.sleep(3000)
@@ -74,7 +74,7 @@ class FakeMemcachedSuite extends FunSuite with MemcachedTestHelpers {
 
   test("set-null") {
     withFakeMemcached { cache =>
-      val op1 = cache.awaitAdd("hello", null, 5.seconds)
+      val op1 = cache.awaitAdd("hello", null, 0, 5.seconds)
       assert(op1 === false)
 
       val stored = cache.awaitGet[Value]("hello")
@@ -87,7 +87,7 @@ class FakeMemcachedSuite extends FunSuite with MemcachedTestHelpers {
       cache.awaitDelete("hello")
       assert(cache.awaitGet[Value]("hello") === None)
 
-      cache.awaitSet("hello", Value("world"), 1.minute)
+      cache.awaitSet("hello", Value("world"), 0, 1.minute)
       assert(cache.awaitGet[Value]("hello") === Some(Value("world")))
 
       assert(cache.awaitDelete("hello") === true)
@@ -103,27 +103,27 @@ class FakeMemcachedSuite extends FunSuite with MemcachedTestHelpers {
       assert(cache.awaitGet[Value]("some-key") === None)
 
       // no can do
-      assert(Await.result(cache.compareAndSet("some-key", Some(Value("invalid")), Value("value1"), 15.seconds), Duration.Inf) === false)
+      assert(Await.result(cache.compareAndSet("some-key", Some(Value("invalid")), Value("value1"), 0, 15.seconds), Duration.Inf) === false)
       assert(cache.awaitGet[Value]("some-key") === None)
 
       // set to value1
-      assert(Await.result(cache.compareAndSet("some-key", None, Value("value1"), 5.seconds), Duration.Inf) === true)
+      assert(Await.result(cache.compareAndSet("some-key", None, Value("value1"), 0, 5.seconds), Duration.Inf) === true)
       assert(cache.awaitGet[Value]("some-key") === Some(Value("value1")))
 
       // no can do
-      assert(Await.result(cache.compareAndSet("some-key", Some(Value("invalid")), Value("value1"), 15.seconds), Duration.Inf) === false)
+      assert(Await.result(cache.compareAndSet("some-key", Some(Value("invalid")), Value("value1"), 0, 15.seconds), Duration.Inf) === false)
       assert(cache.awaitGet[Value]("some-key") === Some(Value("value1")))
 
       // set to value2, from value1
-      assert(Await.result(cache.compareAndSet("some-key", Some(Value("value1")), Value("value2"), 15.seconds), Duration.Inf) === true)
+      assert(Await.result(cache.compareAndSet("some-key", Some(Value("value1")), Value("value2"), 0, 15.seconds), Duration.Inf) === true)
       assert(cache.awaitGet[Value]("some-key") === Some(Value("value2")))
 
       // no can do
-      assert(Await.result(cache.compareAndSet("some-key", Some(Value("invalid")), Value("value1"), 15.seconds), Duration.Inf) === false)
+      assert(Await.result(cache.compareAndSet("some-key", Some(Value("invalid")), Value("value1"), 0, 15.seconds), Duration.Inf) === false)
       assert(cache.awaitGet[Value]("some-key") === Some(Value("value2")))
 
       // set to value3, from value2
-      assert(Await.result(cache.compareAndSet("some-key", Some(Value("value2")), Value("value3"), 15.seconds), Duration.Inf) === true)
+      assert(Await.result(cache.compareAndSet("some-key", Some(Value("value2")), Value("value3"), 0, 15.seconds), Duration.Inf) === true)
       assert(cache.awaitGet[Value]("some-key") === Some(Value("value3")))
     }
   }
@@ -211,7 +211,7 @@ class FakeMemcachedSuite extends FunSuite with MemcachedTestHelpers {
     withFakeMemcached { cache =>
       assert(cache.awaitGet[Int]("hello") === None)
 
-      cache.awaitSet("hello", "123", 1.second)(StringBinaryCodec)
+      cache.awaitSet("hello", "123", 0, 1.second)(StringBinaryCodec)
       assert(cache.awaitGet[String]("hello")(StringBinaryCodec) === Some("123"))
 
       cache.awaitIncrement("hello", 1, None, 1.second)
@@ -230,7 +230,7 @@ class FakeMemcachedSuite extends FunSuite with MemcachedTestHelpers {
     withFakeMemcached { cache =>
       assert(cache.awaitGet[Int]("hello") === None)
 
-      cache.awaitSet("hello", "123", 1.second)(StringBinaryCodec)
+      cache.awaitSet("hello", "123", 0, 1.second)(StringBinaryCodec)
       assert(cache.awaitGet[String]("hello")(StringBinaryCodec) === Some("123"))
 
       cache.awaitIncrement("hello", 5, None, 1.second)
@@ -286,7 +286,7 @@ class FakeMemcachedSuite extends FunSuite with MemcachedTestHelpers {
   test("big-instance-1") {
     withFakeMemcached { cache =>
       val impression = shade.testModels.bigInstance
-      cache.awaitSet(impression.uuid, impression, 60.seconds)
+      cache.awaitSet(impression.uuid, impression, 0, 60.seconds)
       assert(cache.awaitGet[Impression](impression.uuid) === Some(impression))
     }
   }
@@ -300,7 +300,7 @@ class FakeMemcachedSuite extends FunSuite with MemcachedTestHelpers {
       objectOut.writeObject(impression)
       val byteArray = byteOut.toByteArray
 
-      cache.awaitSet(impression.uuid, byteArray, 60.seconds)
+      cache.awaitSet(impression.uuid, byteArray, 0, 60.seconds)
 
       val inBytes = cache.awaitGet[Array[Byte]](impression.uuid)
       assert(inBytes.isDefined)
@@ -311,7 +311,7 @@ class FakeMemcachedSuite extends FunSuite with MemcachedTestHelpers {
   test("big-instance-2") {
     withFakeMemcached { cache =>
       val impression = shade.testModels.bigInstance2
-      cache.awaitSet(impression.uuid, impression, 60.seconds)
+      cache.awaitSet(impression.uuid, impression, 0, 60.seconds)
       assert(cache.awaitGet[Impression](impression.uuid) === Some(impression))
     }
   }
@@ -319,7 +319,7 @@ class FakeMemcachedSuite extends FunSuite with MemcachedTestHelpers {
   test("big-instance-3") {
     withFakeMemcached { cache =>
       val impression = shade.testModels.bigInstance
-      val result = cache.set(impression.uuid, impression, 60.seconds) flatMap { _ =>
+      val result = cache.set(impression.uuid, impression, 0, 60.seconds) flatMap { _ =>
         cache.get[Impression](impression.uuid)
       }
 
@@ -331,7 +331,7 @@ class FakeMemcachedSuite extends FunSuite with MemcachedTestHelpers {
     withFakeMemcached { cache =>
       Thread.sleep(100)
       val impression = shade.testModels.bigInstance2
-      cache.awaitSet(impression.uuid, impression, 60.seconds)
+      cache.awaitSet(impression.uuid, impression, 0, 60.seconds)
       assert(cache.awaitGet[Impression](impression.uuid) === Some(impression))
     }
   }

--- a/src/test/scala/shade/tests/MemcachedSuite.scala
+++ b/src/test/scala/shade/tests/MemcachedSuite.scala
@@ -27,13 +27,13 @@ class MemcachedSuite extends FunSuite with MemcachedTestHelpers {
 
   test("add") {
     withCache("add") { cache =>
-      val op1 = cache.awaitAdd("hello", Value("world"), 5.seconds)
+      val op1 = cache.awaitAdd("hello", Value("world"), 0, 5.seconds)
       assert(op1 === true)
 
       val stored = cache.awaitGet[Value]("hello")
       assert(stored === Some(Value("world")))
 
-      val op2 = cache.awaitAdd("hello", Value("changed"), 5.seconds)
+      val op2 = cache.awaitAdd("hello", Value("changed"), 0, 5.seconds)
       assert(op2 === false)
 
       val changed = cache.awaitGet[Value]("hello")
@@ -43,7 +43,7 @@ class MemcachedSuite extends FunSuite with MemcachedTestHelpers {
 
   test("add-null") {
     withCache("add-null") { cache =>
-      val op1 = cache.awaitAdd("hello", null, 5.seconds)
+      val op1 = cache.awaitAdd("hello", null, 0, 5.seconds)
       assert(op1 === false)
 
       val stored = cache.awaitGet[Value]("hello")
@@ -62,10 +62,10 @@ class MemcachedSuite extends FunSuite with MemcachedTestHelpers {
     withCache("set") { cache =>
       assert(cache.awaitGet[Value]("hello") === None)
 
-      cache.awaitSet("hello", Value("world"), 1.seconds)
+      cache.awaitSet("hello", Value("world"), 0, 1.seconds)
       assert(cache.awaitGet[Value]("hello") === Some(Value("world")))
 
-      cache.awaitSet("hello", Value("changed"), 1.second)
+      cache.awaitSet("hello", Value("changed"), 0, 1.second)
       assert(cache.awaitGet[Value]("hello") === Some(Value("changed")))
 
       Thread.sleep(3000)
@@ -76,7 +76,7 @@ class MemcachedSuite extends FunSuite with MemcachedTestHelpers {
 
   test("set-null") {
     withCache("set-null") { cache =>
-      val op1 = cache.awaitAdd("hello", null, 5.seconds)
+      val op1 = cache.awaitAdd("hello", null, 0, 5.seconds)
       assert(op1 === false)
 
       val stored = cache.awaitGet[Value]("hello")
@@ -89,7 +89,7 @@ class MemcachedSuite extends FunSuite with MemcachedTestHelpers {
       cache.awaitDelete("hello")
       assert(cache.awaitGet[Value]("hello") === None)
 
-      cache.awaitSet("hello", Value("world"), 1.minute)
+      cache.awaitSet("hello", Value("world"), 0, 1.minute)
       assert(cache.awaitGet[Value]("hello") === Some(Value("world")))
 
       assert(cache.awaitDelete("hello") === true)
@@ -105,27 +105,27 @@ class MemcachedSuite extends FunSuite with MemcachedTestHelpers {
       assert(cache.awaitGet[Value]("some-key") === None)
 
       // no can do
-      assert(Await.result(cache.compareAndSet("some-key", Some(Value("invalid")), Value("value1"), 15.seconds), Duration.Inf) === false)
+      assert(Await.result(cache.compareAndSet("some-key", Some(Value("invalid")), Value("value1"), 0, 15.seconds), Duration.Inf) === false)
       assert(cache.awaitGet[Value]("some-key") === None)
 
       // set to value1
-      assert(Await.result(cache.compareAndSet("some-key", None, Value("value1"), 5.seconds), Duration.Inf) === true)
+      assert(Await.result(cache.compareAndSet("some-key", None, Value("value1"), 0, 5.seconds), Duration.Inf) === true)
       assert(cache.awaitGet[Value]("some-key") === Some(Value("value1")))
 
       // no can do
-      assert(Await.result(cache.compareAndSet("some-key", Some(Value("invalid")), Value("value1"), 15.seconds), Duration.Inf) === false)
+      assert(Await.result(cache.compareAndSet("some-key", Some(Value("invalid")), Value("value1"), 0, 15.seconds), Duration.Inf) === false)
       assert(cache.awaitGet[Value]("some-key") === Some(Value("value1")))
 
       // set to value2, from value1
-      assert(Await.result(cache.compareAndSet("some-key", Some(Value("value1")), Value("value2"), 15.seconds), Duration.Inf) === true)
+      assert(Await.result(cache.compareAndSet("some-key", Some(Value("value1")), Value("value2"), 0, 15.seconds), Duration.Inf) === true)
       assert(cache.awaitGet[Value]("some-key") === Some(Value("value2")))
 
       // no can do
-      assert(Await.result(cache.compareAndSet("some-key", Some(Value("invalid")), Value("value1"), 15.seconds), Duration.Inf) === false)
+      assert(Await.result(cache.compareAndSet("some-key", Some(Value("invalid")), Value("value1"), 0, 15.seconds), Duration.Inf) === false)
       assert(cache.awaitGet[Value]("some-key") === Some(Value("value2")))
 
       // set to value3, from value2
-      assert(Await.result(cache.compareAndSet("some-key", Some(Value("value2")), Value("value3"), 15.seconds), Duration.Inf) === true)
+      assert(Await.result(cache.compareAndSet("some-key", Some(Value("value2")), Value("value3"), 0, 15.seconds), Duration.Inf) === true)
       assert(cache.awaitGet[Value]("some-key") === Some(Value("value3")))
     }
   }
@@ -264,7 +264,7 @@ class MemcachedSuite extends FunSuite with MemcachedTestHelpers {
     withCache("increment-decrement") { cache =>
       assert(cache.awaitGet[Int]("hello") === None)
 
-      cache.awaitSet("hello", "123", 1.second)(StringBinaryCodec)
+      cache.awaitSet("hello", "123", 0, 1.second)(StringBinaryCodec)
       assert(cache.awaitGet[String]("hello")(StringBinaryCodec) === Some("123"))
 
       cache.awaitIncrement("hello", 1, None, 1.second)
@@ -283,7 +283,7 @@ class MemcachedSuite extends FunSuite with MemcachedTestHelpers {
     withCache("increment-decrement-delta") { cache =>
       assert(cache.awaitGet[Int]("hello") === None)
 
-      cache.awaitSet("hello", "123", 1.second)(StringBinaryCodec)
+      cache.awaitSet("hello", "123", 0, 1.second)(StringBinaryCodec)
       assert(cache.awaitGet[String]("hello")(StringBinaryCodec) === Some("123"))
 
       cache.awaitIncrement("hello", 5, None, 1.second)
@@ -339,7 +339,7 @@ class MemcachedSuite extends FunSuite with MemcachedTestHelpers {
   test("vector-inherited-case-classes") {
     withCache("vector-inherited-case-classes") { cache =>
       val content = shade.testModels.contentSeq
-      cache.awaitSet("blog-posts", content, 60.seconds)
+      cache.awaitSet("blog-posts", content, 0, 60.seconds)
       assert(cache.awaitGet[Vector[ContentPiece]]("blog-posts") === Some(content))
     }
   }
@@ -347,7 +347,7 @@ class MemcachedSuite extends FunSuite with MemcachedTestHelpers {
   test("big-instance-1") {
     withCache("big-instance-1") { cache =>
       val impression = shade.testModels.bigInstance
-      cache.awaitSet(impression.uuid, impression, 60.seconds)
+      cache.awaitSet(impression.uuid, impression, 0, 60.seconds)
       assert(cache.awaitGet[Impression](impression.uuid) === Some(impression))
     }
   }
@@ -361,7 +361,7 @@ class MemcachedSuite extends FunSuite with MemcachedTestHelpers {
       objectOut.writeObject(impression)
       val byteArray = byteOut.toByteArray
 
-      cache.awaitSet(impression.uuid, byteArray, 60.seconds)
+      cache.awaitSet(impression.uuid, byteArray, 0, 60.seconds)
 
       val inBytes = cache.awaitGet[Array[Byte]](impression.uuid)
       assert(inBytes.isDefined)
@@ -372,7 +372,7 @@ class MemcachedSuite extends FunSuite with MemcachedTestHelpers {
   test("big-instance-2") {
     withCache("big-instance-2") { cache =>
       val impression = shade.testModels.bigInstance2
-      cache.awaitSet(impression.uuid, impression, 60.seconds)
+      cache.awaitSet(impression.uuid, impression, 0, 60.seconds)
       assert(cache.awaitGet[Impression](impression.uuid) === Some(impression))
     }
   }
@@ -380,7 +380,7 @@ class MemcachedSuite extends FunSuite with MemcachedTestHelpers {
   test("big-instance-3") {
     withCache("big-instance-3") { cache =>
       val impression = shade.testModels.bigInstance
-      val result = cache.set(impression.uuid, impression, 60.seconds) flatMap { _ =>
+      val result = cache.set(impression.uuid, impression, 0, 60.seconds) flatMap { _ =>
         cache.get[Impression](impression.uuid)
       }
 
@@ -392,7 +392,7 @@ class MemcachedSuite extends FunSuite with MemcachedTestHelpers {
     withCache("cancel-strategy", failureMode = Some(FailureMode.Cancel)) { cache =>
       Thread.sleep(100)
       val impression = shade.testModels.bigInstance2
-      cache.awaitSet(impression.uuid, impression, 60.seconds)
+      cache.awaitSet(impression.uuid, impression, 0, 60.seconds)
       assert(cache.awaitGet[Impression](impression.uuid) === Some(impression))
     }
   }
@@ -401,7 +401,7 @@ class MemcachedSuite extends FunSuite with MemcachedTestHelpers {
     withCache("infinite-duration") { cache =>
       assert(cache.awaitGet[Value]("hello") === None)
       try {
-        cache.awaitSet("hello", Value("world"), Duration.Inf)
+        cache.awaitSet("hello", Value("world"), 0, Duration.Inf)
         assert(cache.awaitGet[Value]("hello") === Some(Value("world")))
 
         Thread.sleep(5000)


### PR DESCRIPTION
Added setting and reading of the storage flags (as described in https://github.com/memcached/memcached/blob/master/doc/protocol.txt) into the public API.
The intended point of usage is in the `Codec` trait's methods (i.e. serde operations should be aware of the flags, such as compression and similar).

Few notes:
- `FakeMemcached` internals don't support the flags so ignoring/setting 0s where needed
- unit test `MemcachedSuite.increment-default` is failing (it seems that it's been failing in previous builds as well)
- the default codecs in `BaseCodecs` accept but otherwise ignore the flag values