### PR TITLE
Add ability to configure timeoutThreshold

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -62,7 +62,7 @@ resolvers ++= Seq(
 )
 
 libraryDependencies ++= Seq(
-  "net.spy"        %  "spymemcached"    % "2.12.2",
+  "net.spy"        %  "spymemcached"    % "2.12.3",
   "org.slf4j"      %  "slf4j-api"       % "1.7.23",
   "io.monix"       %% "monix-eval"      % "2.3.0",
   "ch.qos.logback" %  "logback-classic" % "1.1.7"  % Test,

--- a/src/main/scala/shade/memcached/Configuration.scala
+++ b/src/main/scala/shade/memcached/Configuration.scala
@@ -38,6 +38,11 @@ import scala.concurrent.duration._
  * @param operationTimeout  is the default operation timeout; When the limit is reached, the
  *                          Future responses finish with Failure(TimeoutException)
  *
+ * @param timeoutThreshold  is the maximum number of timeouts for a connection that will be tolerated before
+ *                          the connection is considered dead and will not be retried. Once this threshold is breached,
+ *                          the client will consider the connection to be lost and attempt to establish a new one.
+ *                          If None, the default Spymemcached implementation is used (998)
+ *
  * @param shouldOptimize    If true, optimization will collapse multiple sequential get ops.
  *
  * @param opQueueFactory    can be used to customize the operations queue,
@@ -63,6 +68,7 @@ case class Configuration(
   protocol: Protocol.Value = Protocol.Binary,
   failureMode: FailureMode.Value = FailureMode.Retry,
   operationTimeout: FiniteDuration = 1.second,
+  timeoutThreshold: Option[Int] = None,
   shouldOptimize: Boolean = false,
   opQueueFactory: Option[OperationQueueFactory] = None,
   writeQueueFactory: Option[OperationQueueFactory] = None,

--- a/src/main/scala/shade/memcached/MemcachedImpl.scala
+++ b/src/main/scala/shade/memcached/MemcachedImpl.scala
@@ -359,16 +359,21 @@ class MemcachedImpl(config: Configuration, ec: ExecutionContext) extends Memcach
           builder
       }
 
+      val withTimeoutThreshold = config.timeoutThreshold match {
+        case Some(threshold) => withTimeout.setTimeoutExceptionThreshold(threshold)
+        case _ => withTimeout
+      }
+
       val withAuth = config.authentication match {
         case Some(credentials) =>
-          withTimeout.setAuthDescriptor(
+          withTimeoutThreshold.setAuthDescriptor(
             new AuthDescriptor(
               Array("PLAIN"),
               new PlainCallbackHandler(credentials.username, credentials.password)
             )
           )
         case None =>
-          withTimeout
+          withTimeoutThreshold
       }
 
       withAuth


### PR DESCRIPTION
By default, the timeout threshold for Spymemcached is [set to 998](https://github.com/couchbase/spymemcached/blob/master/src/main/java/net/spy/memcached/DefaultConnectionFactory.java#L115), which means
that each connection will wait for 998 timeouts before considering [the connection
to be dead](https://github.com/couchbase/spymemcached/blob/master/src/main/java/net/spy/memcached/MemcachedConnection.java#L554-L556) and then [re-establishing a new one](https://github.com/couchbase/spymemcached/blob/master/src/main/java/net/spy/memcached/MemcachedConnection.java#L647-L652).

This changeset adds the ability to configure the threshold from Shade.

Also, bump Spymemcached version to the latest one.